### PR TITLE
Skip checking LNCS if LNCS secret not present

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -26,10 +26,16 @@ jobs:
           node-version: '14'
       - run: npm install
       - name: Create llncs.cls
+        id: createllncs
+        shell: bash
         run: |
            mkdir tmp
-           [[ $LLNCS_CLS ]] && echo "$LLNCS_CLS" > tmp/llncs.cls
-        shell: bash
+           if [ "$LLNCS_CLS" == "" ]; then
+             echo ::set-output name=lncsclspresent::false
+           else
+             echo ::set-output name=lncsclspresent::true
+             echo "$LLNCS_CLS" > tmp/llncs.cls
+           fi
         env:
           LLNCS_CLS: ${{secrets.LLNCS_CLS}}
       - name: Generate template
@@ -53,12 +59,14 @@ jobs:
           ls -la
         env:
           yeoman_test: true
+        if: ${{ steps.createllncs.outputs.lncsclspresent }}
       - name: latexmk
         uses: dante-ev/latex-action@edge
         with:
           root_file: main.tex
           # ${{ github.workspace }} holds wrong directory (only valid for "run" tasks, not for container-based tasks)
           working_directory: '/github/workspace/tmp'
+        if: ${{ steps.createllncs.outputs.lncsclspresent }}
   lncs-lualatex-bibtex:
     runs-on: ubuntu-latest
     strategy:
@@ -84,10 +92,16 @@ jobs:
           node-version: '14'
       - run: npm install
       - name: Create llncs.cls
+        id: createllncs
+        shell: bash
         run: |
            mkdir tmp
-           [[ $LLNCS_CLS ]] && echo "$LLNCS_CLS" > tmp/llncs.cls
-        shell: bash
+           if [ "$LLNCS_CLS" == "" ]; then
+             echo ::set-output name=lncsclspresent::false
+           else
+             echo ::set-output name=lncsclspresent::true
+             echo "$LLNCS_CLS" > tmp/llncs.cls
+           fi
         env:
           LLNCS_CLS: ${{secrets.LLNCS_CLS}}
       - name: Generate template
@@ -111,12 +125,14 @@ jobs:
           ls -la
         env:
           yeoman_test: true
+        if: ${{ steps.createllncs.outputs.lncsclspresent }}
       - name: latexmk
         uses: dante-ev/latex-action@edge
         with:
           root_file: main.tex
           # ${{ github.workspace }} holds wrong directory (only valid for "run" tasks, not for container-based tasks)
           working_directory: '/github/workspace/tmp'
+        if: ${{ steps.createllncs.outputs.lncsclspresent }}
   scientific-thesis-pdflatex-bibtex:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
For forks, the secrets are empty (see e.g., https://stackoverflow.com/q/67368005/873282; https://github.com/latextemplates/generator-latex-template/pull/45). Thus, LNCS cannot be checked. With this PR, the respective checks are skipped if the secret is not present.