### PR TITLE
Refine LTG

### DIFF
--- a/.github/workflows/check-make.yml
+++ b/.github/workflows/check-make.yml
@@ -45,7 +45,7 @@ on:
   merge_group:
   workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.actor_id }}
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 jobs:
   check-make:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 From 2025-01-13 onwards, versioning is done using [Calendar Versioning](https://calver.org/).
 We use dots as date separators, because it is supported in `package.json` (and dashes are not).
 
+## [Unreleased]
+
+### Fixed
+
+- English `\initialism` (used by `\OMG`, `\BPEL`, `\BPMN`, `\UML`) now works: the `lccaps` package providing `\textlcc` is loaded and bundled via `Texlivefile`. Previously `\textlcc` was undefined whenever those macros were used. [#328](https://github.com/latextemplates/generator-latex-template/issues/328)
+- German spell-checking: the generated `.aspell.de.pws` personal dictionary is now tagged with language `de` (was `en`), so `aspell -l de_DE` no longer aborts with "Expected language de but got en". [#369](https://github.com/latextemplates/generator-latex-template/issues/369)
+
 ## [2026.6.26]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ We use dots as date separators, because it is supported in `package.json` (and d
 
 ### Fixed
 
-- English `\initialism` (used by `\OMG`, `\BPEL`, `\BPMN`, `\UML`) now works: the `lccaps` package providing `\textlcc` is loaded and bundled via `Texlivefile`. Previously `\textlcc` was undefined whenever those macros were used. [#328](https://github.com/latextemplates/generator-latex-template/issues/328)
+- English `\initialism` (used by `\OMG`, `\BPEL`, `\BPMN`, `\UML`) now works: the `lccaps` package providing `\textlcc` is loaded and bundled via `Texlivefile`. Previously `\textlcc` was undefined whenever those macros were used. An example in the "Other Features" hints section now demonstrates `\initialism`. [#328](https://github.com/latextemplates/generator-latex-template/issues/328)
 - German spell-checking: the generated `.aspell.de.pws` personal dictionary is now tagged with language `de` (was `en`), so `aspell -l de_DE` no longer aborts with "Expected language de but got en". [#369](https://github.com/latextemplates/generator-latex-template/issues/369)
 
 ## [2026.6.26]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ We use dots as date separators, because it is supported in `package.json` (and d
 
 ## [Unreleased]
 
+### Added
+
+- The generated README now has a FAQ entry explaining how to render the `tikz-uml` UML example on Overleaf: because Overleaf does not fetch the git submodule that provides the package, upload `tikz-uml.sty` into the project. Shown only when `uml=tikz-uml`.
+
 ### Fixed
 
 - English `\initialism` (used by `\OMG`, `\BPEL`, `\BPMN`, `\UML`) now works: the `lccaps` package providing `\textlcc` is loaded and bundled via `Texlivefile`. Previously `\textlcc` was undefined whenever those macros were used. An example in the "Other Features" hints section now demonstrates `\initialism`. [#328](https://github.com/latextemplates/generator-latex-template/issues/328)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,20 @@ layout is a hard requirement.
    (`cd .github && python3 generate-workflows.py`, see "CI & testing in this repo") and
    delete it again before merging unless you intend to ship it on `main`.
 4. **End** — once this repo's `refine-ltg` PR is green, **squash-merge** it into `main`.
+   **Cut the release from `main`, never from `refine-ltg`.** The squash-merge is what
+   carries the cycle onto `main`; releasing from `refine-ltg` publishes an unmerged tree
+   with a not-yet-finalized CHANGELOG — exactly what broke the 2026.6.26 release (a stale
+   `## [2026.6.25]` heading, a missing `[2026.6.26]:` compare link, and an `[Unreleased]:`
+   link that was never bumped). So `git switch main && git pull` and confirm
+   `git branch --show-current` prints `main` **before** touching the CHANGELOG or running
+   `release-it`. Then **verify the CHANGELOG before publishing** (details and the exact
+   heylogs command in README → "Releasing a new version"): run heylogs for **0 problems**
+   (same check as `check-changelog.yml`) **and** eyeball the links by hand — heylogs
+   **cannot** validate version links here, because our CalVer headings omit the date so
+   `linkable`/`date-displayed`/`all-h2-contain-a-version` are off and heylogs skips
+   link-checking a dateless heading. Confirm the top `## [<version>]` equals the version
+   `release-it` will publish, and that both the `[<version>]:` and the bumped
+   `[Unreleased]:` link definitions are present and point at the right tags.
    Then cut the release (README → "Releasing a new version": `release-it` +
    `github-release-from-changelog` — version bump, npm publish, tag, GitHub release; this is
    the only step that needs an interactive npm login + 2FA). Then, on `main`, run
@@ -276,6 +290,10 @@ diff is printed in the failing run's "Prepare files" step, canonical variant **e
   use the *exact* flags from that template's `update-files.yml` (incl. `--texlive` and any
   `--thesisvariant`/`--ieeevariant`): `yeoman_test=true yo <repo>/generators/app/index.js --documentclass=… --texlive=… --lang=en --listings=minted …`.
 - **Lint an EJS template:** `npx ejs-lint generators/app/templates/<file>`.
+- **Check the CHANGELOG locally** (same check as `check-changelog.yml`; run before any
+  release): `jbang com.github.nbbrd.heylogs:heylogs-cli:0.18.1:bin check CHANGELOG.md`
+  (keep the version in sync with `check-changelog.yml`). 0 problems is necessary but **not
+  sufficient** — also verify the version links by hand (see release step 4 above).
 
 ## Local LaTeX testing
 

--- a/README.md
+++ b/README.md
@@ -201,16 +201,23 @@ ejslint.cmd c:\git-repositories\latextemplates\generator-latex-template\generato
 
 ### Releasing a new version
 
-1. Once the `refine-ltg` PR is green, **squash-merge** it into `main`
-2. **important** check `main` out and pull
-3. **ensure that on main** Update `CHANGELOG.md` (change `h2` heading etc.)
-4. **ensure that on main** Update `package.json`, publish to [npmjs](https://www.npmjs.com/package/generator-latex-template), create GitHub release.
+> **Cut the release from `main`, never from `refine-ltg`.**
+> Releasing from the dev branch publishes an unmerged tree with a not-yet-finalized CHANGELOG — that is what broke the 2026.6.26 release (a stale `## [2026.6.25]` heading, a missing `[2026.6.26]:` compare link, and an `[Unreleased]:` link that was never bumped).
+> So after the squash-merge, `git switch main && git pull` and confirm `git branch --show-current` prints `main` before doing anything below.
+
+1. Once the `refine-ltg` PR is green, **squash-merge** it into `main`, then `git switch main && git pull` (confirm you are on `main`).
+2. Update `CHANGELOG.md`: rename the top `## [Unreleased]` heading to `## [<version>]`, add the matching `[<version>]: …/compare/<prev>...<version>` link definition, and bump `[Unreleased]: …/compare/<version>...main`.
+3. **Verify the CHANGELOG before publishing:**
+   - Run heylogs (the same check as CI's `check-changelog.yml`) and get **0 problems**:
+     `jbang com.github.nbbrd.heylogs:heylogs-cli:0.18.1:bin check CHANGELOG.md`
+   - heylogs **cannot** validate the version links here: our CalVer headings omit the date, so `linkable`/`date-displayed`/`all-h2-contain-a-version` are off in `heylogs.properties` and heylogs skips link-checking a dateless heading. So **also check the links by hand** — the top `## [<version>]` must equal the version `release-it` will publish, and both the `[<version>]:` and the bumped `[Unreleased]:` definitions must be present and point at the right tags. Quick grep:
+     `grep -nE '^## \[|^\[Unreleased\]:|^\[<version>\]:' CHANGELOG.md`
+4. Update `package.json`, publish to [npmjs](https://www.npmjs.com/package/generator-latex-template), create GitHub release.
    Use [release-it](https://www.npmjs.com/package/release-it) (do not create a release on GitHub) and [github-release-from-changelog](https://www.npmjs.com/package/github-release-from-changelog).
 
    - `npx release-it`
    - `npx github-release-from-changelog`
-5. **ensure that on main** , run `scripts/end-new-cycle.sh`
-6. **squash-merge** each template's "Update LTG" PR once it is green.
+5. On `main`, run `scripts/end-new-cycle.sh`, then **squash-merge** each template's "Update LTG" PR once it is green.
 
 ## License
 

--- a/generators/app/templates/README.en.md
+++ b/generators/app/templates/README.en.md
@@ -776,14 +776,16 @@ Just answer "(a) allow for this document" and it will work.
 4. Use [pdfscissors](https://sites.google.com/site/pdfscissors) to crop the borders and title (maybe you have to allow <https://sites.google.com> in the Java security center in the control panel).
 5. Include the PDF in LaTeX via `\includegraphics{chart_cropped.pdf}`.
 
+<% if (uml == "tikz-uml") { -%>
+### Q: Overleaf complains about a missing `tikz-uml.sty`.
+
+`tikz-uml` is not part of TeX Live; locally it is provided as a git submodule placed on the `TEXINPUTS` search path (see "UML diagram example" above).
+Overleaf does not fetch git submodules, so `tikz-uml.sty` is unavailable there.
+Download `tikz-uml.sty` from the [tikz-uml repository](https://plmlab.math.cnrs.fr/tikzuml/tikzuml) and upload it into your Overleaf project, next to your main `.tex` file; the UML example then compiles.
+Without it, the example is skipped automatically and the rest of the document still builds.
+
+<% } -%>
 <%#
-### Q: Overleaf complains about missing `.sty` files.
-
-Google for the name of the `sty` and upload it to overleaf.
-As of 2018-02-17, these are:
-
-- `scientific-thesis-cover.sty` - can be downloaded from <https://raw.githubusercontent.com/latextemplates/scientific-thesis-cover/master/scientific-thesis-cover.sty>.
-
 ### Q: My Paderborn title page is strange. The boxes seem to be located arbitrarily.
 
 Just run pdflatex again.

--- a/generators/app/templates/README.en.md
+++ b/generators/app/templates/README.en.md
@@ -782,7 +782,6 @@ Just answer "(a) allow for this document" and it will work.
 Google for the name of the `sty` and upload it to overleaf.
 As of 2018-02-17, these are:
 
-- `lccaps.sty` - can be downloaded from <https://latextemplates.github.io/stys-for-overleaf/>.
 - `scientific-thesis-cover.sty` - can be downloaded from <https://raw.githubusercontent.com/latextemplates/scientific-thesis-cover/master/scientific-thesis-cover.sty>.
 
 ### Q: My Paderborn title page is strange. The boxes seem to be located arbitrarily.

--- a/generators/app/templates/Texlivefile
+++ b/generators/app/templates/Texlivefile
@@ -3,15 +3,15 @@ latexindent
 latexmk
 texlogsieve
 
-amsmath
 <% if (githubpublish || (documentclass == "acmart")) { -%>
 acmart
 <% } -%>
 <% if (githubpublish || isThesis) { -%>
-algorithms
 algorithmicx<%# required by algpseudocodex%>
+algorithms
 algpseudocodex
 <% } -%>
+amsmath
 <% if (githubpublish || (lang == "de")) { -%>
 autotype
 <% } -%>
@@ -21,8 +21,8 @@ babel-english
 <%# german needed for some TeX source code input hacks -%>
 babel-german
 <% if (githubpublish || (bibtextool == "biblatex")) { -%>
-biblatex
 biber
+biblatex
 <% } -%>
 <% if (githubpublish || isThesis) { -%>
 bigfoot<%# provides perpage%>
@@ -51,13 +51,13 @@ comment<%# required by at least acm%>
 csquotes
 ctablestack
 currfile
-datetime2
-<% if (githubpublish || (lang == "de")) { -%>
-datetime2-german
-<% } -%>
-datetime2-english
 <% if (githubpublish || isThesis) { -%>
 datatool
+<% } -%>
+datetime2
+datetime2-english
+<% if (githubpublish || (lang == "de")) { -%>
+datetime2-german
 <% } -%>
 <% if (githubpublish || (lang == "de")) { -%>
 dehyph-exptl
@@ -101,20 +101,18 @@ footmisc
 gettitlestring
 <% if (githubpublish || (documentclass == 'ustutt') || (documentclass == 'scientific-thesis')) { -%>
 glossaries
-<% if (githubpublish || (lang == "de")) { -%>
-glossaries-german
-<% } -%>
 <% if (githubpublish || (lang == "en")) { -%>
 glossaries-english
 <% } -%>
 glossaries-extra
+<% if (githubpublish || (lang == "de")) { -%>
+glossaries-german
+<% } -%>
 <% } -%>
 graphics
 <% if (githubpublish || isThesis) { -%>
 helvetic
 <% } -%>
-hyphenex
-inconsolata<%# required by ustutt, scientific-thesis, acm%>
 hycolor
 hypcap
 hyperref
@@ -124,6 +122,7 @@ hyphen-english
 <% if (githubpublish || (lang == "de")) { -%>
 hyphen-german
 <% } -%>
+hyphenex
 <% if (documentclass == 'ieee') { -%>
 ieeetran
 <% } -%>
@@ -132,6 +131,7 @@ ifmtarg<%# required by acmart at least %>
 ifplatform
 <% } -%>
 iftex
+inconsolata<%# required by ustutt, scientific-thesis, acm%>
 infwarerr
 intcalc
 <% if (githubpublish || isThesis) { -%>
@@ -145,7 +145,6 @@ latex-bin-dev
 latex-bin-dev.x86_64-linux
 <% } -%>
 lccaps
-textcase<%# required by lccaps %>
 letltxmacro
 <% if (githubpublish || (documentclass == "acmart")) { -%>
 libertine
@@ -160,10 +159,10 @@ aliascnt<%# llncs.cls requires it from TeX Live 2026 on; not a separate package 
 <% } -%>
 llncs
 <% } -%>
-ltxcmds
 <% if (githubpublish || isThesis) { -%>
 lscapeenhanced
 <% } -%>
+ltxcmds
 <% if (githubpublish || (reallatexcompiler.startsWith("lualatex"))) { -%>
 luacode
 lualatex-math
@@ -210,30 +209,28 @@ newtx
 newtxtt
 nfssext-cfr
 <% } -%>
+nowidow
 <% if (githubpublish || isThesis) { -%>
 ntheorem
 <% } -%>
-nowidow
 paralist
 pdfcomment
 pdfescape
 <% if (githubpublish || isThesis) { -%>
 pdflscape
-<% } -%>
-pdftexcmds
-<% if (githubpublish || isThesis) { -%>
 pdfpages
 <% } -%>
+pdftexcmds
 <% if (githubpublish || examples) { -%>
 pgf
 pgfplots<%# used by the pgfplots example; also provides pgfplotstable %>
 <% } -%>
-<% if (githubpublish || (uml == "plantuml")) { -%>
-plantuml<%# plantuml.sty for the PlantUML UML example; the diagram also needs an external PlantUML install %>
-<% } -%>
 pict2e
 <% if (githubpublish || (documentclass == "ustutt")) { -%>
 placeins
+<% } -%>
+<% if (githubpublish || (uml == "plantuml")) { -%>
+plantuml<%# plantuml.sty for the PlantUML UML example; the diagram also needs an external PlantUML install %>
 <% } -%>
 <% if ((documentclass == 'acmart') || (documentclass == 'ieee')) { -%>
 preprint<%# this includes balance%>
@@ -279,9 +276,10 @@ svn-prov<%# at least required by acmart, ustutt, scientific-thesis%>
 tabto-ltx
 <% } -%>
 tcolorbox
+tex-gyre<%# at least required by acm, ieee, font config "times"; provides ts1-qtmr %>
 texcount
 texlogsieve
-tex-gyre<%# at least required by acm, ieee, font config "times"; provides ts1-qtmr %>
+textcase<%# required by lccaps %>
 <% if (githubpublish || isThesis) { -%>
 tikzmark
 <% } -%>
@@ -315,8 +313,8 @@ xcharter
 <% } -%>
 xcolor
 <% if (githubpublish || isThesis) { -%>
-xifthen
 xfor
+xifthen
 <% } -%>
 xkeyval
 <% if (githubpublish || (documentclass == "ieee") || (font == "times")) { -%>

--- a/generators/app/templates/Texlivefile
+++ b/generators/app/templates/Texlivefile
@@ -144,6 +144,8 @@ kvsetkeys
 latex-bin-dev
 latex-bin-dev.x86_64-linux
 <% } -%>
+lccaps
+textcase<%# required by lccaps %>
 letltxmacro
 <% if (githubpublish || (documentclass == "acmart")) { -%>
 libertine

--- a/generators/app/templates/dot.aspell.de.pws
+++ b/generators/app/templates/dot.aspell.de.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 122 utf-8
+personal_ws-1.1 de 122 utf-8
 ACM
 Atlantic
 BPEL

--- a/generators/app/templates/lccaps.preamble.en.tex
+++ b/generators/app/templates/lccaps.preamble.en.tex
@@ -1,0 +1,3 @@
+% lccaps provides \textlcc (lowercase caps), used by \initialism in commands.tex.
+% Doc: https://ctan.org/pkg/lccaps
+\usepackage{lccaps}

--- a/generators/app/templates/main.de.tex
+++ b/generators/app/templates/main.de.tex
@@ -325,6 +325,7 @@
   AROMA TOSCA BPMN OASIS OMG DMTF IT DevOps
 }
 
+<%- include('lccaps.preamble.en.tex', this); -%>
 \input{commands}
 <% switch (documentclass) { case "acmart": -%>
 

--- a/generators/app/templates/main.en.tex
+++ b/generators/app/templates/main.en.tex
@@ -303,6 +303,7 @@
   AROMA TOSCA BPMN OASIS OMG DMTF IT DevOps
 }
 
+<%- include('lccaps.preamble.en.tex', this); -%>
 \input{commands}
 <% switch (documentclass) { case "acmart": -%>
 

--- a/generators/app/templates/otherfeatures.example.en.tex
+++ b/generators/app/templates/otherfeatures.example.en.tex
@@ -15,3 +15,10 @@ Brackets work as designed:
 <test>
 One can also input backticks in verbatim text: \verb|`test`|.
 <%- eexample %>
+
+Acronyms can be typeset in running text with \verb+\initialism+, which sets them as small caps that blend into the surrounding lowercase text. It is the lightweight alternative to the full acronym and glossary management (\verb+\gls+, with an automatic list of abbreviations) provided by the thesis variants: \verb+\initialism+ only typesets the acronym and does not add it to any list. The macro and a few ready-made acronyms (\verb+\OMG+, \verb+\BPEL+, \verb+\BPMN+, \verb+\UML+) are defined in \texttt{commands.tex}, where you can add your own.
+
+<%- bexample %>
+The \UML is maintained by the \OMG; related standards include \BPEL and \BPMN.
+Any acronym can be set inline with \initialism{REST} or \initialism{HTTP}.
+<%- eexample %>


### PR DESCRIPTION
Refinement cycle changes.

Fixes #369
Fixes #328

## Changes

- German spell-checking: tag the generated `.aspell.de.pws` personal dictionary with language `de` (was `en`), so `aspell -l de_DE` no longer aborts with "Expected language de but got en". (#369)
- English `\initialism` (`\OMG`/`\BPEL`/`\BPMN`/`\UML`) now works: load the `lccaps` package providing `\textlcc`, bundle it via `Texlivefile`, and add an example to the "Other Features" hints section. `ntheorem`/`definition` from the same issue was already ported. (#328)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
